### PR TITLE
[enh] recreate llm instance when model changed

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -73,11 +73,18 @@ yarn run version-major
 yarn run version-prerelease
 ```
 
+Note: if you need to set the base version first, you can run the following command, e.g.:
+
+```bash
+npx lerna version 0.5.14-alpha.0 --no-push --sync-workspace-lock --no-git-tag-version --force-publish --npm-client=yarn
+ts-node scripts/update-version.mjs
+```
+
 Then, you need to commit the changes of version number in all package.json files, especially the lockfile.
 
 ```bash
 yarn install
-git commit -am "chore: update version number to X.Y.Z"
+git commit -am --signoff "chore: update version number to X.Y.Z"
 ```
 
 2. (Optional)Before pushing the tag, you can test the publishing process:
@@ -114,7 +121,7 @@ The `publish-dry-run` command:
 
 ```bash
 git add .
-git commit -am "chore: update version number to X.Y.Z"
+git commit -am --signoff "chore: update version number to X.Y.Z"
 git push
 ```
 

--- a/examples/vercel_example/package.json
+++ b/examples/vercel_example/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^1.3.21",
     "@openassistant/plots": "workspace:*",
-    "ai": "^4.3.13",
+    "ai": "^4.3.19",
     "dotenv": "^16.4.5",
     "readline-sync": "^1.4.10",
     "zod": "^3.24.4"

--- a/examples/vercel_leaflet_example/package.json
+++ b/examples/vercel_leaflet_example/package.json
@@ -20,7 +20,7 @@
     "@openassistant/plots": "workspace:*",
     "@openassistant/tables": "workspace:*",
     "@openassistant/utils": "workspace:*",
-    "ai": "^4.3.13",
+    "ai": "^4.3.19",
     "dotenv": "^16.4.5",
     "next": "15.3.2",
     "react": "^19.0.0",

--- a/examples/vercel_map_example/package.json
+++ b/examples/vercel_map_example/package.json
@@ -17,7 +17,7 @@
     "@openassistant/map": "workspace:*",
     "@openassistant/osm": "workspace:*",
     "@openassistant/plots": "workspace:*",
-    "ai": "^4.3.13",
+    "ai": "^4.3.19",
     "dotenv": "^16.4.5",
     "next": "14.1.0",
     "react": "^19.0.0",

--- a/examples/vercel_usechat_example/package.json
+++ b/examples/vercel_usechat_example/package.json
@@ -14,7 +14,7 @@
     "@openassistant/duckdb": "workspace:*",
     "@openassistant/echarts": "workspace:*",
     "@openassistant/utils": "workspace:*",
-    "ai": "^4.3.13",
+    "ai": "^4.3.19",
     "dotenv": "^16.4.5",
     "next": "14.1.0",
     "react": "^19.0.0",

--- a/examples/vercel_vega_example/package.json
+++ b/examples/vercel_vega_example/package.json
@@ -13,7 +13,7 @@
     "@ai-sdk/openai": "^1.3.21",
     "@openassistant/plots": "workspace:*",
     "@openassistant/vegalite": "workspace:*",
-    "ai": "^4.3.13",
+    "ai": "^4.3.19",
     "dotenv": "^16.4.5",
     "next": "14.1.0",
     "react": "^18.2.0",

--- a/packages/components/common/CHANGELOG.md
+++ b/packages/components/common/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.14-alpha.2](https://github.com/geodaai/openassistant/compare/@openassistant/common@0.0.5...@openassistant/common@0.5.14-alpha.2) (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/common
+
 ## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/common@0.0.5...@openassistant/common@0.5.14-alpha.1) (2025-07-23)
 
 **Note:** Version bump only for package @openassistant/common

--- a/packages/components/common/CHANGELOG.md
+++ b/packages/components/common/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.14](https://github.com/geodaopenjs/openassistant/compare/@openassistant/common@0.0.5...@openassistant/common@0.5.14) (2025-07-04)
+## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/common@0.0.5...@openassistant/common@0.5.14-alpha.1) (2025-07-23)
+
+**Note:** Version bump only for package @openassistant/common
 
 ## 0.5.14-alpha.0 (2025-07-04)
 

--- a/packages/components/common/package.json
+++ b/packages/components/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/common",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The common components for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/components/common/package.json
+++ b/packages/components/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/common",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The common components for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/components/echarts/CHANGELOG.md
+++ b/packages/components/echarts/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.14-alpha.2](https://github.com/geodaai/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.14-alpha.2) (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/echarts
+
 ## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.14-alpha.1) (2025-07-23)
 
 ## [0.5.14-alpha.0](https://github.com/geodaai/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.14-alpha.0) (2025-07-23)

--- a/packages/components/echarts/CHANGELOG.md
+++ b/packages/components/echarts/CHANGELOG.md
@@ -3,23 +3,9 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.14](https://github.com/geodaopenjs/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.14) (2025-07-04)
+## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.14-alpha.1) (2025-07-23)
 
-## 0.5.14-alpha.0 (2025-07-04)
-
-## 0.5.13 (2025-06-24)
-
-## 0.5.12 (2025-06-20)
-
-## 0.5.11 (2025-06-18)
-
-## 0.5.9 (2025-06-13)
-
-## 0.5.8 (2025-06-12)
-
-**Note:** Version bump only for package @openassistant/echarts
-
-## [0.5.14-alpha.0](https://github.com/geodaopenjs/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.14-alpha.0) (2025-07-04)
+## [0.5.14-alpha.0](https://github.com/geodaai/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.14-alpha.0) (2025-07-23)
 
 ## 0.5.13 (2025-06-24)
 
@@ -30,54 +16,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## 0.5.9 (2025-06-13)
 
 ## 0.5.8 (2025-06-12)
-
-**Note:** Version bump only for package @openassistant/echarts
-
-## [0.5.13](https://github.com/geodaopenjs/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.13) (2025-06-24)
-
-## 0.5.12 (2025-06-20)
-
-## 0.5.11 (2025-06-18)
-
-## 0.5.9 (2025-06-13)
-
-## 0.5.8 (2025-06-12)
-
-**Note:** Version bump only for package @openassistant/echarts
-
-## [0.5.12](https://github.com/geodaopenjs/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.12) (2025-06-20)
-
-## 0.5.11 (2025-06-18)
-
-## 0.5.9 (2025-06-13)
-
-## 0.5.8 (2025-06-12)
-
-**Note:** Version bump only for package @openassistant/echarts
-
-## [0.5.11](https://github.com/geodaopenjs/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.11) (2025-06-18)
-
-## 0.5.9 (2025-06-13)
-
-## 0.5.8 (2025-06-12)
-
-**Note:** Version bump only for package @openassistant/echarts
-
-## [0.5.10](https://github.com/geodaopenjs/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.10) (2025-06-18)
-
-## 0.5.9 (2025-06-13)
-
-## 0.5.8 (2025-06-12)
-
-**Note:** Version bump only for package @openassistant/echarts
-
-## [0.5.9](https://github.com/geodaopenjs/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.9) (2025-06-13)
-
-## 0.5.8 (2025-06-12)
-
-**Note:** Version bump only for package @openassistant/echarts
-
-## [0.5.8](https://github.com/geodaopenjs/openassistant/compare/@openassistant/echarts@0.0.5...@openassistant/echarts@0.5.8) (2025-06-12)
 
 **Note:** Version bump only for package @openassistant/echarts
 

--- a/packages/components/echarts/package.json
+++ b/packages/components/echarts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/echarts",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The eCharts components for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/components/echarts/package.json
+++ b/packages/components/echarts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/echarts",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The eCharts components for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/components/hooks/CHANGELOG.md
+++ b/packages/components/hooks/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/hooks
+
+## 0.5.14-alpha.0 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/hooks
+
 ## 0.5.14 (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/components/hooks/CHANGELOG.md
+++ b/packages/components/hooks/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.2 (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/hooks
+
 ## 0.5.14-alpha.1 (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/components/hooks/package.json
+++ b/packages/components/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/hooks",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The hooks for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/components/hooks/package.json
+++ b/packages/components/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/hooks",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The hooks for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/components/keplergl/CHANGELOG.md
+++ b/packages/components/keplergl/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/keplergl
+
+## 0.5.14-alpha.0 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/keplergl
+
 ## 0.5.14 (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/components/keplergl/CHANGELOG.md
+++ b/packages/components/keplergl/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.2 (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/keplergl
+
 ## 0.5.14-alpha.1 (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/components/keplergl/package.json
+++ b/packages/components/keplergl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/keplergl",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The Kepler.gl Component for OpenAssistant",
   "main": "dist/index.cjs.js",

--- a/packages/components/keplergl/package.json
+++ b/packages/components/keplergl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/keplergl",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The Kepler.gl Component for OpenAssistant",
   "main": "dist/index.cjs.js",

--- a/packages/components/leaflet/CHANGELOG.md
+++ b/packages/components/leaflet/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/leaflet
+
+## 0.5.14-alpha.0 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/leaflet
+
 ## 0.5.14 (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/components/leaflet/CHANGELOG.md
+++ b/packages/components/leaflet/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.2 (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/leaflet
+
 ## 0.5.14-alpha.1 (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/components/leaflet/package.json
+++ b/packages/components/leaflet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/leaflet",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The Leaflet components for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/components/leaflet/package.json
+++ b/packages/components/leaflet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/leaflet",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The Leaflet components for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/components/tables/CHANGELOG.md
+++ b/packages/components/tables/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.2 (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/tables
+
 ## 0.5.14-alpha.1 (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/components/tables/CHANGELOG.md
+++ b/packages/components/tables/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/tables
+
+## 0.5.14-alpha.0 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/tables
+
 ## 0.5.14 (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/components/tables/package.json
+++ b/packages/components/tables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/tables",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The Tables components for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/components/tables/package.json
+++ b/packages/components/tables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/tables",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The Tables components for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/components/vegalite/CHANGELOG.md
+++ b/packages/components/vegalite/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.2 (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/vegalite
+
 ## 0.5.14-alpha.1 (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/components/vegalite/CHANGELOG.md
+++ b/packages/components/vegalite/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/vegalite
+
+## 0.5.14-alpha.0 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/vegalite
+
 ## 0.5.14 (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/components/vegalite/package.json
+++ b/packages/components/vegalite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/vegalite",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The Vega-Lite components for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/components/vegalite/package.json
+++ b/packages/components/vegalite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/vegalite",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The Vega-Lite components for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,64 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/core@0.0.5...@openassistant/core@0.5.14-alpha.1) (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+### Bug Fixes
+
+* ollama streamText not working ([fbfa874](https://github.com/geodaai/openassistant/commit/fbfa874decaee537639a9fbf62d6ca28796c79ef))
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+## 0.4.4 (2025-05-22)
+
+## 0.4.3 (2025-05-20)
+
+## 0.4.2 (2025-05-20)
+
+### Features
+
+* allow using tools directly with vercel ai sdk ([#17](https://github.com/geodaai/openassistant/issues/17)) ([fef9fa2](https://github.com/geodaai/openassistant/commit/fef9fa2d21938c304a4415c7b2fc3972280e0908))
+* update playground ([#15](https://github.com/geodaai/openassistant/issues/15)) ([6ed4ca9](https://github.com/geodaai/openassistant/commit/6ed4ca97901626b84eb5667bdbab3d38cc33570a))
+
+## 0.0.6 (2025-01-21)
+
+## [0.5.14-alpha.0](https://github.com/geodaai/openassistant/compare/@openassistant/core@0.0.5...@openassistant/core@0.5.14-alpha.0) (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+### Bug Fixes
+
+* ollama streamText not working ([fbfa874](https://github.com/geodaai/openassistant/commit/fbfa874decaee537639a9fbf62d6ca28796c79ef))
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+## 0.4.4 (2025-05-22)
+
+## 0.4.3 (2025-05-20)
+
+## 0.4.2 (2025-05-20)
+
+### Features
+
+* allow using tools directly with vercel ai sdk ([#17](https://github.com/geodaai/openassistant/issues/17)) ([fef9fa2](https://github.com/geodaai/openassistant/commit/fef9fa2d21938c304a4415c7b2fc3972280e0908))
+* update playground ([#15](https://github.com/geodaai/openassistant/issues/15)) ([6ed4ca9](https://github.com/geodaai/openassistant/commit/6ed4ca97901626b84eb5667bdbab3d38cc33570a))
+
+## 0.0.6 (2025-01-21)
+
 ## [0.5.14](https://github.com/geodaopenjs/openassistant/compare/@openassistant/core@0.0.5...@openassistant/core@0.5.14) (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.14-alpha.2](https://github.com/geodaai/openassistant/compare/@openassistant/core@0.0.5...@openassistant/core@0.5.14-alpha.2) (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+### Bug Fixes
+
+* ollama streamText not working ([fbfa874](https://github.com/geodaai/openassistant/commit/fbfa874decaee537639a9fbf62d6ca28796c79ef))
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+## 0.4.4 (2025-05-22)
+
+## 0.4.3 (2025-05-20)
+
+## 0.4.2 (2025-05-20)
+
+### Features
+
+* allow using tools directly with vercel ai sdk ([#17](https://github.com/geodaai/openassistant/issues/17)) ([fef9fa2](https://github.com/geodaai/openassistant/commit/fef9fa2d21938c304a4415c7b2fc3972280e0908))
+* update playground ([#15](https://github.com/geodaai/openassistant/issues/15)) ([6ed4ca9](https://github.com/geodaai/openassistant/commit/6ed4ca97901626b84eb5667bdbab3d38cc33570a))
+
+## 0.0.6 (2025-01-21)
+
 ## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/core@0.0.5...@openassistant/core@0.5.14-alpha.1) (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/core",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "Core library using Vercel AI SDK for OpenAssistant",
   "main": "src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "@ai-sdk/react": "^1.2.11",
     "@ai-sdk/ui-utils": "^1.2.10",
     "@langchain/core": "^0.3.38",
-    "ai": "^4.3.13",
+    "ai": "^4.3.19",
     "openai": "^4.93.0",
     "openai-zod-functions": "^0.1.2",
     "zod": "^3.24.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,7 +44,7 @@
     "@ai-sdk/deepseek": "^0.1.8",
     "@ai-sdk/google": "^1.1.8",
     "@ai-sdk/xai": "^1.1.8",
-    "ollama-ai-provider-v2": "^0.0.5",
+    "ollama-ai-provider-v2": "^0.0.6",
     "react": ">=18.2"
   },
   "peerDependenciesMeta": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/core",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "Core library using Vercel AI SDK for OpenAssistant",
   "main": "src/index.ts",

--- a/packages/core/src/hooks/use-assistant.ts
+++ b/packages/core/src/hooks/use-assistant.ts
@@ -71,6 +71,8 @@ export type UseAssistantProps = {
   abortController?: AbortController;
   /** Optional custom headers to include in API requests. */
   headers?: Record<string, string>;
+  /** Optional raw mode for ollama. */
+  raw?: boolean;
 };
 
 /**

--- a/packages/core/src/llm/anthropic.ts
+++ b/packages/core/src/llm/anthropic.ts
@@ -37,8 +37,18 @@ export class AnthropicAssistant extends VercelAiClient {
   }
 
   public static override configure(config: VercelAiClientConfigureProps) {
+    // Check if model has changed
+    const modelChanged = config.model && config.model !== AnthropicAssistant.model;
+    
     // call parent configure
     super.configure(config);
+    
+    // If model changed, reset the instance to force recreation
+    if (modelChanged) {
+      if (AnthropicAssistant.instance) {
+        AnthropicAssistant.instance.restart();
+      }
+    }
   }
 
   private static async loadModule(): Promise<Module> {

--- a/packages/core/src/llm/deepseek.ts
+++ b/packages/core/src/llm/deepseek.ts
@@ -31,8 +31,18 @@ export class DeepSeekAssistant extends VercelAiClient {
   }
 
   public static override configure(config: VercelAiClientConfigureProps) {
+    // Check if model has changed
+    const modelChanged = config.model && config.model !== DeepSeekAssistant.model;
+    
     // call parent configure
     super.configure(config);
+    
+    // If model changed, reset the instance to force recreation
+    if (modelChanged) {
+      if (DeepSeekAssistant.instance) {
+        DeepSeekAssistant.instance.restart();
+      }
+    }
   }
 
   private static async loadModule(): Promise<Module> {

--- a/packages/core/src/llm/google.ts
+++ b/packages/core/src/llm/google.ts
@@ -31,8 +31,18 @@ export class GoogleAIAssistant extends VercelAiClient {
   }
 
   public static override configure(config: VercelAiClientConfigureProps) {
+    // Check if model has changed
+    const modelChanged = config.model && config.model !== GoogleAIAssistant.model;
+    
     // call parent configure
     super.configure(config);
+    
+    // If model changed, reset the instance to force recreation
+    if (modelChanged) {
+      if (GoogleAIAssistant.instance) {
+        GoogleAIAssistant.instance.restart();
+      }
+    }
   }
 
   private static async loadModule(): Promise<Module> {

--- a/packages/core/src/llm/grok.ts
+++ b/packages/core/src/llm/grok.ts
@@ -27,8 +27,18 @@ export class XaiAssistant extends VercelAiClient {
   }
 
   public static override configure(config: VercelAiClientConfigureProps) {
+    // Check if model has changed
+    const modelChanged = config.model && config.model !== XaiAssistant.model;
+    
     // call parent configure
     super.configure(config);
+    
+    // If model changed, reset the instance to force recreation
+    if (modelChanged) {
+      if (XaiAssistant.instance) {
+        XaiAssistant.instance.restart();
+      }
+    }
   }
 
   private static async loadModule(): Promise<Module> {

--- a/packages/core/src/llm/ollama.ts
+++ b/packages/core/src/llm/ollama.ts
@@ -15,6 +15,8 @@ type ConfigureProps = {
 
 type OllamaChatSettings = {
   raw?: boolean;
+  simulateStreaming?: boolean;
+  stream?: boolean;
 };
 
 type OllamaProvider = (
@@ -70,12 +72,24 @@ export class OllamaAssistant extends VercelAiClient {
   public static override configure(config: ConfigureProps) {
     // remove baseURL from config
     const { baseURL, raw, ...rest } = config;
+    
+    // Check if baseURL or model has changed
+    const baseURLChanged = baseURL && baseURL !== OllamaAssistant.baseURL;
+    const modelChanged = rest.model && rest.model !== OllamaAssistant.model;
+    
     // config baseURL
     if (baseURL) OllamaAssistant.baseURL = baseURL;
     // config raw
     if (raw) OllamaAssistant.raw = raw;
     // call parent configure, with config without baseURL
     super.configure(rest);
+    
+    // If baseURL or model changed, reset the instance to force recreation
+    if (baseURLChanged || modelChanged) {
+      if (OllamaAssistant.instance) {
+        OllamaAssistant.instance.restart();
+      }
+    }
   }
 
   private constructor(module: Module) {

--- a/packages/core/src/llm/openai.ts
+++ b/packages/core/src/llm/openai.ts
@@ -33,8 +33,18 @@ export class OpenAIAssistant extends VercelAiClient {
   }
 
   public static override configure(config: VercelAiClientConfigureProps) {
+    // Check if model has changed
+    const modelChanged = config.model && config.model !== OpenAIAssistant.model;
+    
     // call parent configure
     super.configure(config);
+    
+    // If model changed, reset the instance to force recreation
+    if (modelChanged) {
+      if (OpenAIAssistant.instance) {
+        OpenAIAssistant.instance.restart();
+      }
+    }
   }
 
   public static async testConnection(

--- a/packages/core/src/llm/vercelai-client.ts
+++ b/packages/core/src/llm/vercelai-client.ts
@@ -323,7 +323,6 @@ export abstract class VercelAiClient extends VercelAi {
       temperature: VercelAiClient.temperature,
       ...(VercelAiClient.topP !== undefined && { topP: VercelAiClient.topP }),
       maxSteps,
-      maxTokens: VercelAiClient.maxTokens,
       abortSignal: this.abortController?.signal,
       ...(Object.keys(VercelAiClient.headers).length > 0 && { headers: VercelAiClient.headers }),
       onStepFinish: async (event: StepResult<ToolSet>) => {

--- a/packages/core/src/llm/vercelai-client.ts
+++ b/packages/core/src/llm/vercelai-client.ts
@@ -323,6 +323,7 @@ export abstract class VercelAiClient extends VercelAi {
       temperature: VercelAiClient.temperature,
       ...(VercelAiClient.topP !== undefined && { topP: VercelAiClient.topP }),
       maxSteps,
+      maxTokens: VercelAiClient.maxTokens,
       abortSignal: this.abortController?.signal,
       ...(Object.keys(VercelAiClient.headers).length > 0 && { headers: VercelAiClient.headers }),
       onStepFinish: async (event: StepResult<ToolSet>) => {

--- a/packages/core/src/utils/create-assistant.ts
+++ b/packages/core/src/utils/create-assistant.ts
@@ -62,8 +62,9 @@ export async function createAssistant(props: UseAssistantProps) {
     toolChoice: props.toolChoice,
     maxSteps: props.maxSteps,
     toolCallStreaming: props.toolCallStreaming,
-    ...(props.baseUrl ? { baseURL: props.baseUrl } : {}),
+    ...(props.baseUrl? { baseURL: props.baseUrl} : {}),
     ...(props.headers ? { headers: props.headers } : {}),
+    ...(props.raw ? { raw: props.raw } : {}),
   });
 
   // register custom functions using Vercel Tool format

--- a/packages/tools/duckdb/CHANGELOG.md
+++ b/packages/tools/duckdb/CHANGELOG.md
@@ -3,6 +3,46 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/duckdb@0.0.5...@openassistant/duckdb@0.5.14-alpha.1) (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+### Bug Fixes
+
+* duckdb table creation error with column mixed with Polygon and MultiPolygon Features ([a831403](https://github.com/geodaai/openassistant/commit/a8314033bd9b287025865a08a56c3b758e27e848))
+
+### Features
+
+* add cartogram tool ([8bad930](https://github.com/geodaai/openassistant/commit/8bad93067ac8e80ac90a8ef413d3846786de1f5d))
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+## [0.5.14-alpha.0](https://github.com/geodaai/openassistant/compare/@openassistant/duckdb@0.0.5...@openassistant/duckdb@0.5.14-alpha.0) (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+### Bug Fixes
+
+* duckdb table creation error with column mixed with Polygon and MultiPolygon Features ([a831403](https://github.com/geodaai/openassistant/commit/a8314033bd9b287025865a08a56c3b758e27e848))
+
+### Features
+
+* add cartogram tool ([8bad930](https://github.com/geodaai/openassistant/commit/8bad93067ac8e80ac90a8ef413d3846786de1f5d))
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
 ## [0.5.14](https://github.com/geodaopenjs/openassistant/compare/@openassistant/duckdb@0.0.5...@openassistant/duckdb@0.5.14) (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/tools/duckdb/CHANGELOG.md
+++ b/packages/tools/duckdb/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.14-alpha.2](https://github.com/geodaai/openassistant/compare/@openassistant/duckdb@0.0.5...@openassistant/duckdb@0.5.14-alpha.2) (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+### Bug Fixes
+
+* duckdb table creation error with column mixed with Polygon and MultiPolygon Features ([a831403](https://github.com/geodaai/openassistant/commit/a8314033bd9b287025865a08a56c3b758e27e848))
+
+### Features
+
+* add cartogram tool ([8bad930](https://github.com/geodaai/openassistant/commit/8bad93067ac8e80ac90a8ef413d3846786de1f5d))
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
 ## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/duckdb@0.0.5...@openassistant/duckdb@0.5.14-alpha.1) (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/tools/duckdb/package.json
+++ b/packages/tools/duckdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/duckdb",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "description": "The duckdb SQL query addon for OpenAssistant",
   "author": "Xun Li<lixun910@gmail.com>",
   "license": "MIT",

--- a/packages/tools/duckdb/package.json
+++ b/packages/tools/duckdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/duckdb",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "description": "The duckdb SQL query addon for OpenAssistant",
   "author": "Xun Li<lixun910@gmail.com>",
   "license": "MIT",

--- a/packages/tools/geoda/CHANGELOG.md
+++ b/packages/tools/geoda/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.14-alpha.2](https://github.com/geodaai/openassistant/compare/@openassistant/geoda@0.0.5...@openassistant/geoda@0.5.14-alpha.2) (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+### Bug Fixes
+
+* rate tool ([a39d972](https://github.com/geodaai/openassistant/commit/a39d9725ff2c50d725fca694c69215a4fc5c74e3))
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.10 (2025-06-18)
+
+### Features
+
+* add cartogram tool ([8bad930](https://github.com/geodaai/openassistant/commit/8bad93067ac8e80ac90a8ef413d3846786de1f5d))
+
+## 0.5.9 (2025-06-13)
+
+### Bug Fixes
+
+* box plot component not linking correct ids ([86b640f](https://github.com/geodaai/openassistant/commit/86b640f82b93da3ac714753b4a3dff300ca1812a))
+
+## 0.5.8 (2025-06-12)
+
 ## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/geoda@0.0.5...@openassistant/geoda@0.5.14-alpha.1) (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/tools/geoda/CHANGELOG.md
+++ b/packages/tools/geoda/CHANGELOG.md
@@ -3,6 +3,58 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/geoda@0.0.5...@openassistant/geoda@0.5.14-alpha.1) (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+### Bug Fixes
+
+* rate tool ([a39d972](https://github.com/geodaai/openassistant/commit/a39d9725ff2c50d725fca694c69215a4fc5c74e3))
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.10 (2025-06-18)
+
+### Features
+
+* add cartogram tool ([8bad930](https://github.com/geodaai/openassistant/commit/8bad93067ac8e80ac90a8ef413d3846786de1f5d))
+
+## 0.5.9 (2025-06-13)
+
+### Bug Fixes
+
+* box plot component not linking correct ids ([86b640f](https://github.com/geodaai/openassistant/commit/86b640f82b93da3ac714753b4a3dff300ca1812a))
+
+## 0.5.8 (2025-06-12)
+
+## [0.5.14-alpha.0](https://github.com/geodaai/openassistant/compare/@openassistant/geoda@0.0.5...@openassistant/geoda@0.5.14-alpha.0) (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+### Bug Fixes
+
+* rate tool ([a39d972](https://github.com/geodaai/openassistant/commit/a39d9725ff2c50d725fca694c69215a4fc5c74e3))
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.10 (2025-06-18)
+
+### Features
+
+* add cartogram tool ([8bad930](https://github.com/geodaai/openassistant/commit/8bad93067ac8e80ac90a8ef413d3846786de1f5d))
+
+## 0.5.9 (2025-06-13)
+
+### Bug Fixes
+
+* box plot component not linking correct ids ([86b640f](https://github.com/geodaai/openassistant/commit/86b640f82b93da3ac714753b4a3dff300ca1812a))
+
+## 0.5.8 (2025-06-12)
+
 ## [0.5.14](https://github.com/geodaopenjs/openassistant/compare/@openassistant/geoda@0.0.5...@openassistant/geoda@0.5.14) (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/tools/geoda/package.json
+++ b/packages/tools/geoda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/geoda",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The GeoDa spatial analysis tools for OpenAssistant",
   "main": "dist/index.cjs.js",

--- a/packages/tools/geoda/package.json
+++ b/packages/tools/geoda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/geoda",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The GeoDa spatial analysis tools for OpenAssistant",
   "main": "dist/index.cjs.js",

--- a/packages/tools/map/CHANGELOG.md
+++ b/packages/tools/map/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.2 (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/map
+
 ## 0.5.14-alpha.1 (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/tools/map/CHANGELOG.md
+++ b/packages/tools/map/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/map
+
+## 0.5.14-alpha.0 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/map
+
 ## 0.5.14 (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/tools/map/package.json
+++ b/packages/tools/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/map",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The map tools for OpenAssistant",
   "main": "dist/index.cjs.js",

--- a/packages/tools/map/package.json
+++ b/packages/tools/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/map",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The map tools for OpenAssistant",
   "main": "dist/index.cjs.js",

--- a/packages/tools/osm/CHANGELOG.md
+++ b/packages/tools/osm/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/osm
+
+## 0.5.14-alpha.0 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/osm
+
 ## 0.5.14 (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/tools/osm/CHANGELOG.md
+++ b/packages/tools/osm/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.2 (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+**Note:** Version bump only for package @openassistant/osm
+
 ## 0.5.14-alpha.1 (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/tools/osm/package.json
+++ b/packages/tools/osm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/osm",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The OSM tools for OpenAssistant",
   "main": "dist/index.cjs.js",

--- a/packages/tools/osm/package.json
+++ b/packages/tools/osm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/osm",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The OSM tools for OpenAssistant",
   "main": "dist/index.cjs.js",

--- a/packages/tools/plots/CHANGELOG.md
+++ b/packages/tools/plots/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+### Bug Fixes
+
+* box plot component not linking correct ids ([86b640f](https://github.com/geodaai/openassistant/commit/86b640f82b93da3ac714753b4a3dff300ca1812a))
+
+## 0.5.8 (2025-06-12)
+
+## 0.5.14-alpha.0 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+### Bug Fixes
+
+* box plot component not linking correct ids ([86b640f](https://github.com/geodaai/openassistant/commit/86b640f82b93da3ac714753b4a3dff300ca1812a))
+
+## 0.5.8 (2025-06-12)
+
 ## 0.5.14 (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/tools/plots/CHANGELOG.md
+++ b/packages/tools/plots/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.2 (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+### Bug Fixes
+
+* box plot component not linking correct ids ([86b640f](https://github.com/geodaai/openassistant/commit/86b640f82b93da3ac714753b4a3dff300ca1812a))
+
+## 0.5.8 (2025-06-12)
+
 ## 0.5.14-alpha.1 (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/tools/plots/package.json
+++ b/packages/tools/plots/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/plots",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The plot tools for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/tools/plots/package.json
+++ b/packages/tools/plots/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/plots",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "author": "Xun Li<lixun910@gmail.com>",
   "description": "The plot tools for OpenAssistant",
   "main": "./dist/index.cjs.js",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/ui@0.0.5...@openassistant/ui@0.5.14-alpha.1) (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+## 0.4.4 (2025-05-22)
+
+## 0.4.3 (2025-05-20)
+
+## 0.4.2 (2025-05-20)
+
+### Features
+
+* allow using tools directly with vercel ai sdk ([#17](https://github.com/geodaai/openassistant/issues/17)) ([fef9fa2](https://github.com/geodaai/openassistant/commit/fef9fa2d21938c304a4415c7b2fc3972280e0908))
+* update playground ([#15](https://github.com/geodaai/openassistant/issues/15)) ([6ed4ca9](https://github.com/geodaai/openassistant/commit/6ed4ca97901626b84eb5667bdbab3d38cc33570a))
+
+## 0.0.6 (2025-01-21)
+
+## [0.5.14-alpha.0](https://github.com/geodaai/openassistant/compare/@openassistant/ui@0.0.5...@openassistant/ui@0.5.14-alpha.0) (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+## 0.4.4 (2025-05-22)
+
+## 0.4.3 (2025-05-20)
+
+## 0.4.2 (2025-05-20)
+
+### Features
+
+* allow using tools directly with vercel ai sdk ([#17](https://github.com/geodaai/openassistant/issues/17)) ([fef9fa2](https://github.com/geodaai/openassistant/commit/fef9fa2d21938c304a4415c7b2fc3972280e0908))
+* update playground ([#15](https://github.com/geodaai/openassistant/issues/15)) ([6ed4ca9](https://github.com/geodaai/openassistant/commit/6ed4ca97901626b84eb5667bdbab3d38cc33570a))
+
+## 0.0.6 (2025-01-21)
+
 ## [0.5.14](https://github.com/geodaopenjs/openassistant/compare/@openassistant/ui@0.0.5...@openassistant/ui@0.5.14) (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.14-alpha.2](https://github.com/geodaai/openassistant/compare/@openassistant/ui@0.0.5...@openassistant/ui@0.5.14-alpha.2) (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+## 0.4.4 (2025-05-22)
+
+## 0.4.3 (2025-05-20)
+
+## 0.4.2 (2025-05-20)
+
+### Features
+
+* allow using tools directly with vercel ai sdk ([#17](https://github.com/geodaai/openassistant/issues/17)) ([fef9fa2](https://github.com/geodaai/openassistant/commit/fef9fa2d21938c304a4415c7b2fc3972280e0908))
+* update playground ([#15](https://github.com/geodaai/openassistant/issues/15)) ([6ed4ca9](https://github.com/geodaai/openassistant/commit/6ed4ca97901626b84eb5667bdbab3d38cc33570a))
+
+## 0.0.6 (2025-01-21)
+
 ## [0.5.14-alpha.1](https://github.com/geodaai/openassistant/compare/@openassistant/ui@0.0.5...@openassistant/ui@0.5.14-alpha.1) (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,7 +45,7 @@
     "@iconify/react": "^5.1.0",
     "@openassistant/core": "workspace:*",
     "@openassistant/utils": "workspace:*",
-    "ai": "^4.3.16",
+    "ai": "^4.3.19",
     "framer-motion": "^11.15.0",
     "html2canvas": "^1.4.1",
     "next-themes": "^0.4.4",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/ui",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "description": "Chat UI components for OpenAssistant",
   "author": "Xun Li<lixun910@gmail.com>",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/ui",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "description": "Chat UI components for OpenAssistant",
   "author": "Xun Li<lixun910@gmail.com>",
   "license": "MIT",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,50 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+## 0.4.4 (2025-05-22)
+
+## 0.4.3 (2025-05-20)
+
+## 0.4.2 (2025-05-20)
+
+### Features
+
+* allow using tools directly with vercel ai sdk ([#17](https://github.com/geodaai/openassistant/issues/17)) ([fef9fa2](https://github.com/geodaai/openassistant/commit/fef9fa2d21938c304a4415c7b2fc3972280e0908))
+
+## 0.5.14-alpha.0 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+## 0.4.4 (2025-05-22)
+
+## 0.4.3 (2025-05-20)
+
+## 0.4.2 (2025-05-20)
+
+### Features
+
+* allow using tools directly with vercel ai sdk ([#17](https://github.com/geodaai/openassistant/issues/17)) ([fef9fa2](https://github.com/geodaai/openassistant/commit/fef9fa2d21938c304a4415c7b2fc3972280e0908))
+
 ## 0.5.14 (2025-07-04)
 
 ## 0.5.14-alpha.0 (2025-07-04)

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.5.14-alpha.2 (2025-07-24)
+
+## 0.5.14-alpha.1 (2025-07-23)
+
+## 0.5.13 (2025-06-24)
+
+## 0.5.12 (2025-06-20)
+
+## 0.5.11 (2025-06-18)
+
+## 0.5.9 (2025-06-13)
+
+## 0.5.8 (2025-06-12)
+
+## 0.4.4 (2025-05-22)
+
+## 0.4.3 (2025-05-20)
+
+## 0.4.2 (2025-05-20)
+
+### Features
+
+* allow using tools directly with vercel ai sdk ([#17](https://github.com/geodaai/openassistant/issues/17)) ([fef9fa2](https://github.com/geodaai/openassistant/commit/fef9fa2d21938c304a4415c7b2fc3972280e0908))
+
 ## 0.5.14-alpha.1 (2025-07-23)
 
 ## 0.5.13 (2025-06-24)

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/utils",
-  "version": "0.5.14-alpha.1",
+  "version": "0.5.14-alpha.2",
   "description": "Utility functions for OpenAssistant tools",
   "author": "Xun Li<lixun910@gmail.com>",
   "license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openassistant/utils",
-  "version": "0.5.14",
+  "version": "0.5.14-alpha.1",
   "description": "Utility functions for OpenAssistant tools",
   "author": "Xun Li<lixun910@gmail.com>",
   "license": "MIT",

--- a/packages/utils/src/version.ts
+++ b/packages/utils/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.5.14-alpha.1';
+export const VERSION = '0.5.14-alpha.2';

--- a/packages/utils/src/version.ts
+++ b/packages/utils/src/version.ts
@@ -1,4 +1,1 @@
-// SPDX-License-Identifier: MIT
-// Copyright contributors to the openassistant project
-
-export const VERSION = '0.5.14';
+export const VERSION = '0.5.14-alpha.1';

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,24 +134,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/react@npm:1.2.11, @ai-sdk/react@npm:^1.2.11":
-  version: 1.2.11
-  resolution: "@ai-sdk/react@npm:1.2.11"
-  dependencies:
-    "@ai-sdk/provider-utils": "npm:2.2.7"
-    "@ai-sdk/ui-utils": "npm:1.2.10"
-    swr: "npm:^2.2.5"
-    throttleit: "npm:2.1.0"
-  peerDependencies:
-    react: ^18 || ^19 || ^19.0.0-rc
-    zod: ^3.23.8
-  peerDependenciesMeta:
-    zod:
-      optional: true
-  checksum: d5e22ce348caca679243b1a2fb1f90082d1a681fed139bf900a78e7b1da267d40d8d901ae5380ee3d7749101307eca51de13119dab8cdc5d8b6319e323936109
-  languageName: node
-  linkType: hard
-
 "@ai-sdk/react@npm:1.2.12":
   version: 1.2.12
   resolution: "@ai-sdk/react@npm:1.2.12"
@@ -167,6 +149,24 @@ __metadata:
     zod:
       optional: true
   checksum: 1809d785f8c9df65620576aa04d08d1ca1d1e3905518d833837d5cc5c2d489e31ffecb78c301ac209e354dc4f8b13d48ccea0966d3bbc5b654aab1633c19b6ca
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/react@npm:^1.2.11":
+  version: 1.2.11
+  resolution: "@ai-sdk/react@npm:1.2.11"
+  dependencies:
+    "@ai-sdk/provider-utils": "npm:2.2.7"
+    "@ai-sdk/ui-utils": "npm:1.2.10"
+    swr: "npm:^2.2.5"
+    throttleit: "npm:2.1.0"
+  peerDependencies:
+    react: ^18 || ^19 || ^19.0.0-rc
+    zod: ^3.23.8
+  peerDependenciesMeta:
+    zod:
+      optional: true
+  checksum: d5e22ce348caca679243b1a2fb1f90082d1a681fed139bf900a78e7b1da267d40d8d901ae5380ee3d7749101307eca51de13119dab8cdc5d8b6319e323936109
   languageName: node
   linkType: hard
 
@@ -6433,7 +6433,7 @@ __metadata:
     "@ai-sdk/react": "npm:^1.2.11"
     "@ai-sdk/ui-utils": "npm:^1.2.10"
     "@langchain/core": "npm:^0.3.38"
-    ai: "npm:^4.3.13"
+    ai: "npm:^4.3.19"
     openai: "npm:^4.93.0"
     openai-zod-functions: "npm:^0.1.2"
     zod: "npm:^3.24.4"
@@ -6636,7 +6636,7 @@ __metadata:
     "@iconify/react": "npm:^5.1.0"
     "@openassistant/core": "workspace:*"
     "@openassistant/utils": "workspace:*"
-    ai: "npm:^4.3.16"
+    ai: "npm:^4.3.19"
     framer-motion: "npm:^11.15.0"
     html2canvas: "npm:^1.4.1"
     next-themes: "npm:^0.4.4"
@@ -11152,29 +11152,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ai@npm:^4.3.13":
-  version: 4.3.13
-  resolution: "ai@npm:4.3.13"
-  dependencies:
-    "@ai-sdk/provider": "npm:1.1.3"
-    "@ai-sdk/provider-utils": "npm:2.2.7"
-    "@ai-sdk/react": "npm:1.2.11"
-    "@ai-sdk/ui-utils": "npm:1.2.10"
-    "@opentelemetry/api": "npm:1.9.0"
-    jsondiffpatch: "npm:0.6.0"
-  peerDependencies:
-    react: ^18 || ^19 || ^19.0.0-rc
-    zod: ^3.23.8
-  peerDependenciesMeta:
-    react:
-      optional: true
-  checksum: e0330043a7f2062ff755e6ebf217ab9e30ad8ba89bc89d2dabbc4cb3141c1d4296efe7ce1ea91f55a00e6837bb29b92af5e849d549172fd24a3d1b23cfbab25c
-  languageName: node
-  linkType: hard
-
-"ai@npm:^4.3.16":
-  version: 4.3.16
-  resolution: "ai@npm:4.3.16"
+"ai@npm:^4.3.19":
+  version: 4.3.19
+  resolution: "ai@npm:4.3.19"
   dependencies:
     "@ai-sdk/provider": "npm:1.1.3"
     "@ai-sdk/provider-utils": "npm:2.2.8"
@@ -11188,7 +11168,7 @@ __metadata:
   peerDependenciesMeta:
     react:
       optional: true
-  checksum: c48e0b61239708f4fdce2a3f177e21d85dad1e6c28f100bcc06faf00a6bb6884b3683bf8f6354e45d6c207853ca9c22c33141b1aad5cc0d948ed5e50605aa115
+  checksum: a0f398ce82f2b5ed29106acd227658e56a8ef107a00068878ef95b01c9cbe051d341cafe56340f7731a75e42a04635d058cde04baaa7f65912f2254b6d5ce3f1
   languageName: node
   linkType: hard
 
@@ -26755,7 +26735,7 @@ __metadata:
     "@types/node": "npm:^20.0.0"
     "@types/react": "npm:^19.0.0"
     "@types/react-dom": "npm:^19.0.0"
-    ai: "npm:^4.3.13"
+    ai: "npm:^4.3.19"
     autoprefixer: "npm:^10.4.16"
     dotenv: "npm:^16.4.5"
     next: "npm:15.3.2"
@@ -26785,7 +26765,7 @@ __metadata:
     "@types/node": "npm:^20.0.0"
     "@types/react": "npm:^19.0.0"
     "@types/react-dom": "npm:^19.0.0"
-    ai: "npm:^4.3.13"
+    ai: "npm:^4.3.19"
     autoprefixer: "npm:^10.4.16"
     dotenv: "npm:^16.4.5"
     next: "npm:14.1.0"
@@ -26811,7 +26791,7 @@ __metadata:
     "@types/node": "npm:^20.0.0"
     "@types/react": "npm:^19.0.0"
     "@types/react-dom": "npm:^19.0.0"
-    ai: "npm:^4.3.13"
+    ai: "npm:^4.3.19"
     autoprefixer: "npm:^10.4.16"
     dotenv: "npm:^16.4.5"
     next: "npm:14.1.0"
@@ -26836,7 +26816,7 @@ __metadata:
     "@types/node": "npm:^20.0.0"
     "@types/react": "npm:^18.2.0"
     "@types/react-dom": "npm:^18.2.0"
-    ai: "npm:^4.3.13"
+    ai: "npm:^4.3.19"
     autoprefixer: "npm:^10.4.16"
     dotenv: "npm:^16.4.5"
     next: "npm:14.1.0"
@@ -26856,7 +26836,7 @@ __metadata:
   dependencies:
     "@ai-sdk/openai": "npm:^1.3.21"
     "@openassistant/plots": "workspace:*"
-    ai: "npm:^4.3.13"
+    ai: "npm:^4.3.19"
     dotenv: "npm:^16.4.5"
     readline-sync: "npm:^1.4.10"
     zod: "npm:^3.24.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6443,7 +6443,7 @@ __metadata:
     "@ai-sdk/deepseek": ^0.1.8
     "@ai-sdk/google": ^1.1.8
     "@ai-sdk/xai": ^1.1.8
-    ollama-ai-provider-v2: ^0.0.5
+    ollama-ai-provider-v2: ^0.0.9
     react: ">=18.2"
   peerDependenciesMeta:
     "@ai-sdk/anthropic":

--- a/yarn.lock
+++ b/yarn.lock
@@ -6443,7 +6443,7 @@ __metadata:
     "@ai-sdk/deepseek": ^0.1.8
     "@ai-sdk/google": ^1.1.8
     "@ai-sdk/xai": ^1.1.8
-    ollama-ai-provider-v2: ^0.0.9
+    ollama-ai-provider-v2: ^0.0.6
     react: ">=18.2"
   peerDependenciesMeta:
     "@ai-sdk/anthropic":


### PR DESCRIPTION
The Mistral 0.3 supports function calling with Ollama’s raw mode.
This PR is trying to add the option "raw" for Ollama model.

To include "raw": true in your HTTP body when calling an Ollama model via streamText(), you cannot pass it via providerOptions. Instead, you must configure it in the model constructor using createOllama(), then pass that configured model into streamText().

```
const model = ollama('my-model', {
  raw: true,
});
```
