### PR TITLE
feat: add bedrock provider

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "zod-to-json-schema": "^3.24.1"
   },
   "peerDependencies": {
+    "@ai-sdk/amazon-bedrock": "^1.1.6",
     "@ai-sdk/anthropic": "^1.1.14",
     "@ai-sdk/deepseek": "^0.1.8",
     "@ai-sdk/google": "^1.1.8",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,10 @@ export * from './llm/google';
 
 export * from './llm/grok';
 
+export * from './llm/anthropic';
+
+export * from './llm/bedrock';
+
 export * from './llm/ollama';
 
 export * from './llm/vercelai';

--- a/packages/core/src/lib/model-utils.ts
+++ b/packages/core/src/lib/model-utils.ts
@@ -8,6 +8,7 @@ import { OpenAIAssistant } from '../llm/openai';
 import { VercelAi } from '../llm/vercelai';
 import { XaiAssistant } from '../llm/grok';
 import { AnthropicAssistant } from '../llm/anthropic';
+import { BedrockAssistant } from '../llm/bedrock';
 
 /**
  * Returns the appropriate Assistant model based on the provider. (Internal use)
@@ -36,9 +37,9 @@ import { AnthropicAssistant } from '../llm/anthropic';
  * ```
  *
  * @param {Object} options - The options object
- * @param {string} [options.provider] - The name of the AI provider. The supported providers are: 'openai', 'anthropic', 'google', 'deepseek', 'xai', 'ollama'
+ * @param {string} [options.provider] - The name of the AI provider. The supported providers are: 'openai', 'anthropic', 'google', 'deepseek', 'xai', 'ollama', 'bedrock'
  * @param {string} [options.chatEndpoint] - The chat endpoint that handles the chat requests, e.g. '/api/chat'. This is required for server-side support.
- * @returns {typeof VercelAi | typeof AnthropicAssistant | typeof OpenAIAssistant | typeof GoogleAIAssistant | typeof DeepSeekAssistant | typeof XaiAssistant | typeof OllamaAssistant} The assistant model class.
+ * @returns {typeof VercelAi | typeof AnthropicAssistant | typeof OpenAIAssistant | typeof GoogleAIAssistant | typeof DeepSeekAssistant | typeof XaiAssistant | typeof OllamaAssistant | typeof BedrockAssistant} The assistant model class.
  */
 export function GetAssistantModelByProvider({
   provider,
@@ -53,7 +54,8 @@ export function GetAssistantModelByProvider({
   | typeof GoogleAIAssistant
   | typeof DeepSeekAssistant
   | typeof XaiAssistant
-  | typeof OllamaAssistant {
+  | typeof OllamaAssistant
+  | typeof BedrockAssistant {
   // server-side support
   if (chatEndpoint) {
     return VercelAi;
@@ -72,6 +74,8 @@ export function GetAssistantModelByProvider({
       return XaiAssistant;
     case 'ollama':
       return OllamaAssistant;
+    case 'bedrock':
+      return BedrockAssistant;
     default:
       return OpenAIAssistant;
   }

--- a/packages/core/src/llm/bedrock.ts
+++ b/packages/core/src/llm/bedrock.ts
@@ -42,15 +42,16 @@ export class BedrockAssistant extends VercelAiClient {
     // Check if model has changed
     const modelChanged =
       config.model && config.model !== BedrockAssistant.model;
-    const regionChanged =
-      config.region && config.region !== BedrockAssistant.region;
+    const baseURLChanged =
+      config.baseURL && config.baseURL !== BedrockAssistant.baseURL;
 
     // call parent configure
     super.configure(config);
     if (config.region) BedrockAssistant.region = config.region;
+    if (config.baseURL) BedrockAssistant.baseURL = config.baseURL;
 
-    // If model or region changed, reset the instance to force recreation
-    if (modelChanged || regionChanged) {
+    // If model or baseURL changed, reset the instance to force recreation
+    if (modelChanged || baseURLChanged) {
       if (BedrockAssistant.instance) {
         BedrockAssistant.instance.restart();
       }

--- a/packages/core/src/llm/bedrock.ts
+++ b/packages/core/src/llm/bedrock.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the openassistant project
+
+import {
+  VercelAiClient,
+  VercelAiClientConfigureProps,
+} from './vercelai-client';
+import { testConnection } from '../utils/connection-test';
+import { LanguageModelV1 } from 'ai';
+
+type BedrockProvider = (model: string) => LanguageModelV1;
+interface Module {
+  createBedrock: (options: {
+    region: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+  }) => BedrockProvider;
+}
+
+const DEFAULT_BEDROCK_REGION = 'us-east-1';
+const DEFAULT_BEDROCK_BASE_URL = 'https://bedrock.us-east-1.amazonaws.com';
+
+/**
+ * AWS Bedrock Assistant LLM for Client only
+ */
+export class BedrockAssistant extends VercelAiClient {
+  protected static region = DEFAULT_BEDROCK_REGION;
+
+  protected static baseURL = DEFAULT_BEDROCK_BASE_URL;
+
+  protected providerInstance: BedrockProvider | null = null;
+
+  protected static instance: BedrockAssistant | null = null;
+
+  public static getRegion() {
+    return BedrockAssistant.region;
+  }
+
+  public static override configure(
+    config: VercelAiClientConfigureProps & { region?: string }
+  ) {
+    // Check if model has changed
+    const modelChanged =
+      config.model && config.model !== BedrockAssistant.model;
+    const regionChanged =
+      config.region && config.region !== BedrockAssistant.region;
+
+    // call parent configure
+    super.configure(config);
+    if (config.region) BedrockAssistant.region = config.region;
+
+    // If model or region changed, reset the instance to force recreation
+    if (modelChanged || regionChanged) {
+      if (BedrockAssistant.instance) {
+        BedrockAssistant.instance.restart();
+      }
+    }
+  }
+
+  private static async loadModule(): Promise<Module> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore the package will be installed by the user and loaded dynamically
+      return await import('@ai-sdk/amazon-bedrock');
+    } catch (error) {
+      throw new Error(`Failed to load @ai-sdk/amazon-bedrock: ${error}`);
+    }
+  }
+
+  public static async testConnection(
+    apiKey: string,
+    model: string
+  ): Promise<boolean> {
+    const module = await this.loadModule();
+    // For Bedrock, apiKey is expected to be in format "accessKeyId:secretAccessKey"
+    const credentials = apiKey.split(':');
+    const accessKeyId = credentials[0] || '';
+    const secretAccessKey = credentials[1] || '';
+
+    const bedrock = module.createBedrock({
+      region: BedrockAssistant.region,
+      ...(accessKeyId && { accessKeyId }),
+      ...(secretAccessKey && { secretAccessKey }),
+    });
+    return await testConnection(bedrock(model));
+  }
+
+  private constructor(module: Module) {
+    super();
+    this.initializeProvider(module);
+  }
+
+  private initializeProvider(module: Module) {
+    if (
+      BedrockAssistant.apiKey ||
+      BedrockAssistant.baseURL !== DEFAULT_BEDROCK_BASE_URL
+    ) {
+      // For Bedrock, apiKey is treated as accessKeyId and we need to parse secretAccessKey
+      // This is a simplified approach - in practice, you might want to handle credentials differently
+      const credentials = BedrockAssistant.apiKey.split(':');
+      const accessKeyId = credentials[0] || '';
+      const secretAccessKey = credentials[1] || '';
+
+      const options = {
+        region: BedrockAssistant.region,
+        ...(accessKeyId && { accessKeyId }),
+        ...(secretAccessKey && { secretAccessKey }),
+      };
+
+      this.providerInstance = module.createBedrock(options);
+
+      if (!this.providerInstance) {
+        throw new Error('Failed to initialize Bedrock');
+      }
+
+      this.llm = this.providerInstance(BedrockAssistant.model);
+    }
+  }
+
+  public static async getInstance(): Promise<BedrockAssistant> {
+    if (!BedrockAssistant.instance) {
+      const module = await this.loadModule();
+      BedrockAssistant.instance = new BedrockAssistant(module);
+    }
+
+    if (!BedrockAssistant.instance.llm) {
+      BedrockAssistant.instance.restart();
+      throw new Error('BedrockAssistant is not initialized');
+    }
+    return BedrockAssistant.instance;
+  }
+
+  public override restart() {
+    super.restart();
+    // need to reset the instance so getInstance doesn't return the same instance
+    this.providerInstance = null;
+    BedrockAssistant.instance = null;
+  }
+}

--- a/packages/core/src/llm/vercelai.ts
+++ b/packages/core/src/llm/vercelai.ts
@@ -99,6 +99,7 @@ type VercelAiConfigureProps = {
   toolChoice?: ToolChoice<ToolSet>;
   toolCallStreaming?: boolean;
   headers?: Record<string, string>;
+  baseURL?: string;
 };
 
 /**
@@ -118,6 +119,7 @@ export class VercelAi extends AbstractAssistant {
   protected static maxTokens = 128000; // 128k tokens
   protected static hasInitializedServer = false;
   protected static headers: Record<string, string> = {};
+  protected static baseURL = '';
 
   // used by each processTextMessage call
   protected toolSteps = 0;
@@ -173,6 +175,7 @@ export class VercelAi extends AbstractAssistant {
     if (config.toolCallStreaming !== undefined)
       VercelAi.toolCallStreaming = config.toolCallStreaming;
     if (config.headers) VercelAi.headers = config.headers;
+    if (config.baseURL) VercelAi.baseURL = config.baseURL;
   }
 
   public static override registerTool({

--- a/yarn.lock
+++ b/yarn.lock
@@ -6439,6 +6439,7 @@ __metadata:
     zod: "npm:^3.24.4"
     zod-to-json-schema: "npm:^3.24.1"
   peerDependencies:
+    "@ai-sdk/amazon-bedrock": ^1.1.6
     "@ai-sdk/anthropic": ^1.1.14
     "@ai-sdk/deepseek": ^0.1.8
     "@ai-sdk/google": ^1.1.8


### PR DESCRIPTION
This pull request adds support for the AWS Bedrock AI provider to the core package, enabling users to select Bedrock as an option for language model operations. The changes integrate Bedrock into the provider selection logic, update relevant types and documentation, and introduce a new implementation for the Bedrock assistant.

**Bedrock Integration**

* Added `@ai-sdk/amazon-bedrock` as a peer dependency in `package.json` to enable Bedrock support.
* Exported Bedrock-related modules from `index.ts` for public API access.
* Imported `BedrockAssistant` in `model-utils.ts` and updated the provider selection logic and types to include 'bedrock' as a supported provider. [[1]](diffhunk://#diff-32f486bc3c53c304644f3e2731fb110cdd500b82d086dfa014ab4d22d8968217R11) [[2]](diffhunk://#diff-32f486bc3c53c304644f3e2731fb110cdd500b82d086dfa014ab4d22d8968217L39-R42) [[3]](diffhunk://#diff-32f486bc3c53c304644f3e2731fb110cdd500b82d086dfa014ab4d22d8968217L56-R58) [[4]](diffhunk://#diff-32f486bc3c53c304644f3e2731fb110cdd500b82d086dfa014ab4d22d8968217R77-R78)

**New Bedrock Assistant Implementation**

* Added a new file `llm/bedrock.ts` that implements the `BedrockAssistant` class, handling configuration, dynamic loading of the Bedrock SDK, credential parsing, and instance management for Bedrock-based language models.